### PR TITLE
migrate-tjdavey-to-devnq

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tjdavey/devnq.git"
+    "url": "git+https://github.com/devnq/devnq.git"
   },
   "author": "Tristan Davey <tristan@tristandavey.com>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/tjdavey/devnq/issues"
+    "url": "https://github.com/devnq/devnq/issues"
   },
-  "homepage": "https://github.com/tjdavey/devnq#readme",
+  "homepage": "https://github.com/devnq/devnq#readme",
   "devDependencies": {
     "@fortawesome/fontawesome": "^1.1.3",
     "@fortawesome/fontawesome-free-brands": "^5.0.6",


### PR DESCRIPTION
Small update to the `package.json` to point metadata to this repository