### PR TITLE
[FIX] Update meetup API usage for signature authentication deprecation

### DIFF
--- a/webpack/components/meetup.js
+++ b/webpack/components/meetup.js
@@ -4,7 +4,7 @@ import * as meetup from './meetup';
 export function getNextMeetup(callback) {
   xhr({
       method: "get",
-      uri: "https://d2qrtp8csnyzho.cloudfront.net/dev_nq/events?scroll=next_upcoming&photo-host=public&page=1&sig_id=204758206&sig=f08d518a43af7703b557e4d77dc2a85cd18a28b0",
+      uri: "https://d2qrtp8csnyzho.cloudfront.net/dev_nq/events?scroll=next_upcoming&photo-host=public&page=1",
   }, function (err, resp, body) {
     if(resp.statusCode == 200) {
       return callback(null, JSON.parse(body));


### PR DESCRIPTION
Signed URL requests have been deprecated by Meetup's API, this removes the signed URL portion and defaults to unauthenticated (which is now supported). 